### PR TITLE
Fix LaTeX typo and bug when running on server

### DIFF
--- a/notes/G01-PolynomialRegression.ipynb
+++ b/notes/G01-PolynomialRegression.ipynb
@@ -54,13 +54,13 @@
    "metadata": {},
    "source": [
     "## Fitting functions\n",
-    "Suppose we are interested in an unknown function $f:\\R \\to \\R$. We have seen that we can approximate functions $f$ using polynomial interpolation by matching values of $f$ with the polynomials at the interpolation nodes. In many cases, interpolation is not the best way to fit a function. We can relax the requirement of matching values at some nodes by performing a polynomial expansion as a linear model to fit against $f$ instead.\n",
+    "Suppose we are interested in an unknown function $f: \\mathbb{R} \\to \\mathbb{R}$. We have seen that we can approximate functions $f$ using polynomial interpolation by matching values of $f$ with the polynomials at the interpolation nodes. In many cases, interpolation is not the best way to fit a function. We can relax the requirement of matching values at some nodes by performing a polynomial expansion as a linear model to fit against $f$ instead.\n",
     "\n",
     "Define the linear model $\\tilde{f}$ to be\n",
     "\n",
     "$$ \\tilde{f}(x) = \\sum_{i=0}^N c_i P_i(x) = c^\\top P(x)$$\n",
     "\n",
-    "where $c = (c_0, \\dots, c_N) \\in \\R^{N+1}$ is the undetermined parameter vector, $P(x) = (P_0(x), \\dots, P_N(x)) \\in \\R^{N+1}$ and $P_i(x)$ is a polynomial basis of degree $i$ such as the monomial polynomials of $P_i(x) = x^i$, and $N \\in \\mathbb{N}^+$ is the maximum degree of polynomial basis that the linear model has up to."
+    "where $c = (c_0, \\dots, c_N) \\in \\mathbb{R}^{N+1}$ is the undetermined parameter vector, $P(x) = (P_0(x), \\dots, P_N(x)) \\in \\mathbb{R}^{N+1}$ and $P_i(x)$ is a polynomial basis of degree $i$ such as the monomial polynomials of $P_i(x) = x^i$, and $N \\in \\mathbb{N}^+$ is the maximum degree of polynomial basis that the linear model has up to."
    ]
   },
   {
@@ -70,11 +70,11 @@
     "## The Linear Least Square Problem\n",
     "Given a set of $M$ training data $\\{(x_j, y_j)\\}_{j=1, \\dots, M}$ where $y_j = f(x_j)$, we want to find the undetermined parameters $c^*$ in our linear model $\\tilde{f}$ that approximates $f$ well. One possible way is to minimize the difference square between the observed values and model fitting values at each training data $x_j$.\n",
     "\n",
-    "$$c^* = \\argmin_{c \\in \\R^n} \\sum_{j=1}^M \\|y_j - \\tilde{f}(x_j)\\|^2$$\n",
+    "$$c^* = argmin_{c \\in \\mathbb{R}^n} \\sum_{j=1}^M \\|y_j - \\tilde{f}(x_j)\\|^2$$\n",
     "\n",
     "This minimization/loss function can be written in a matrix multiplication form, similar to the interpolation as a linear system with Vandermonde matrix.\n",
     "\n",
-    "$$ c^* = \\argmin_{c \\in \\R^n} \\| Y - Ac \\|^2 = \\argmin_{c \\in \\R^n} \\| Ac - Y \\|^2$$ \n",
+    "$$ c^* = argmin_{c \\in \\mathbb{R}^n} \\| Y - Ac \\|^2 = argmin_{c \\in \\mathbb{R}^n} \\| Ac - Y \\|^2$$ \n",
     "where\n",
     "$$ A = \\begin{pmatrix}\n",
     "        P_1(x_1) & P_2(x_1) &  \\cdots & P_N(x_1)  \\\\ \n",
@@ -353,7 +353,7 @@
    "source": [
     "## Regularization\n",
     "To control overfitting, we can add a regularization term to the loss function as\n",
-    "$$ \\argmin_{c \\in \\R^n} \\| Ac - Y \\|^2 + \\lambda \\| c \\|^2$$\n",
+    "$$ argmin_{c \\in \\mathbb{R}^n} \\| Ac - Y \\|^2 + \\lambda \\| c \\|^2$$\n",
     "where $\\lambda$ is a regularization coefficient that controls the relative strength of regularization. The regularization term here is the sum-of-squares of the parameter vector elements.\n",
     "\n",
     "There are various kinds of regularization terms. A more general regularizer is defined as\n",
@@ -397,7 +397,7 @@
     "   Y = f.(Xtrain)\n",
     "   A = design_matrix(Xtrain, basis, N)\n",
     "   Reg = λ*I(N)\n",
-    "   A = [A; Reg]\n",
+    "   A = Matrix([A; Reg])\n",
     "   Y = [Y; zeros(N)]\n",
     "   Q,R = qr(A)\n",
     "   c = R \\ (Matrix(Q)'*Y)\n",
@@ -442,15 +442,15 @@
   },
   "celltoolbar": "Slideshow",
   "kernelspec": {
-   "display_name": "Julia 1.8.0",
+   "display_name": "Julia 1.7.3",
    "language": "julia",
-   "name": "julia-1.8"
+   "name": "julia-1.7"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.8.0"
+   "version": "1.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
When running on the server, it requires a Matrix type wrapper for the sparse matrix to perform QR factorization.